### PR TITLE
[Security] 2643 - SQL Injection

### DIFF
--- a/trunk/include/mailerlite-admin.php
+++ b/trunk/include/mailerlite-admin.php
@@ -58,12 +58,23 @@ class MailerLite_Admin {
 	}
 
 	function ajax_get_more_groups() {
+		if( !current_user_can( 'administrator' ) ) {
+			wp_die(
+				'You must be an administrator to use this plugin',
+				'Plugin Error',
+				[ 'response' => 403, 'back_link' => true ]
+			);
+		}
+
 		global $wpdb;
 
-		$form = $wpdb->get_row(
-			"SELECT * FROM " . $wpdb->base_prefix
-			. "mailerlite_forms WHERE id = " . $_POST['form_id']
+		$query = $wpdb->prepare(
+			"SELECT *
+			FROM {$wpdb->base_prefix}mailerlite_forms
+			WHERE id=%d",
+			$_POST['form_id']
 		);
+		$form = $wpdb->get_row($query);
 
 		$form->data = unserialize( $form->data );
 
@@ -220,10 +231,13 @@ class MailerLite_Admin {
 
 			$form_id = absint( $_GET['id'] );
 
-			$form = $wpdb->get_row(
-				"SELECT * FROM " . $wpdb->base_prefix
-				. "mailerlite_forms WHERE id = " . $form_id
+			$query = $wpdb->prepare(
+				"SELECT *
+				FROM {$wpdb->base_prefix}mailerlite_forms
+				WHERE id=%d",
+				$form_id
 			);
+			$form = $wpdb->get_row($query);
 
 			if ( isset( $form->data ) ) {
 				$form->data = unserialize( $form->data );
@@ -310,7 +324,7 @@ class MailerLite_Admin {
 
 						$form_selected_groups =[];
 						$selected_groups = explode(';*',$_POST['selected_groups']);
-						
+
 						foreach ($selected_groups as $group) {
 							$group = explode('::', $group);
 							$group_data = [];
@@ -414,9 +428,12 @@ class MailerLite_Admin {
 					include( MAILERLITE_PLUGIN_DIR . 'include/templates/admin/edit_embedded.php' );
 				}
 			} else {
-				$forms_data = $wpdb->get_results(
-					"SELECT * FROM " . $wpdb->base_prefix . "mailerlite_forms ORDER BY time DESC"
-				);
+				$query = "
+					SELECT * FROM
+					{$wpdb->base_prefix}mailerlite_forms
+					ORDER BY time DESC
+				";
+				$forms_data = $wpdb->get_results($query);
 
 				include( MAILERLITE_PLUGIN_DIR . 'include/templates/admin/main.php' );
 			}
@@ -430,10 +447,12 @@ class MailerLite_Admin {
 			wp_redirect( 'admin.php?page=mailerlite_main' );
 		} // Signup forms list
 		else {
-			$forms_data = $wpdb->get_results(
-				"SELECT * FROM " . $wpdb->base_prefix
-				. "mailerlite_forms ORDER BY time DESC"
-			);
+			$query = "
+				SELECT * FROM
+				{$wpdb->base_prefix}mailerlite_forms
+				ORDER BY time DESC
+			";
+			$forms_data = $wpdb->get_results($query);
 
 			include( MAILERLITE_PLUGIN_DIR . 'include/templates/admin/main.php' );
 		}

--- a/trunk/include/mailerlite-admin.php
+++ b/trunk/include/mailerlite-admin.php
@@ -54,18 +54,9 @@ class MailerLite_Admin {
 		}
 
 		add_action( 'wp_ajax_mailerlite_get_more_groups', 'MailerLite_Admin::ajax_get_more_groups' );
-		add_action( 'wp_ajax_nopriv_mailerlite_get_more_groups', 'MailerLite_Admin::ajax_get_more_groups' );
 	}
 
 	function ajax_get_more_groups() {
-		if( !current_user_can( 'administrator' ) ) {
-			wp_die(
-				'You must be an administrator to use this plugin',
-				'Plugin Error',
-				[ 'response' => 403, 'back_link' => true ]
-			);
-		}
-
 		global $wpdb;
 
 		$query = $wpdb->prepare(

--- a/trunk/include/mailerlite-form.php
+++ b/trunk/include/mailerlite-form.php
@@ -58,10 +58,13 @@ class MailerLite_Form {
 		$api_key = get_option( 'mailerlite_api_key' );
 
 		if ( $form_id > 0 && isset( $form_fields['email'] ) ) {
-			$form = $wpdb->get_row(
-				"SELECT * FROM " . $wpdb->base_prefix
-				. "mailerlite_forms WHERE id = " . $form_id
+			$query = $wpdb->prepare(
+				"SELECT * FROM
+				{$wpdb->base_prefix}mailerlite_forms
+				WHERE id = %d",
+				$form_id
 			);
+			$form = $wpdb->get_row($query);
 
 			if ( isset( $form->data ) ) {
 
@@ -199,7 +202,13 @@ add_action(
 function load_mailerlite_form( $form_id ) {
 	global $wpdb;
 
-	$form = $wpdb->get_row( "SELECT * FROM " . $wpdb->base_prefix . "mailerlite_forms WHERE id = " . $form_id );
+	$query = $wpdb->prepare(
+		"SELECT * FROM
+		{$wpdb->base_prefix}mailerlite_forms
+		WHERE id = %d",
+		$form_id
+	);
+	$form = $wpdb->get_row($query);
 
 	if ( isset( $form->data ) ) {
 		$form_data = unserialize( $form->data );

--- a/trunk/include/mailerlite-gutenberg.php
+++ b/trunk/include/mailerlite-gutenberg.php
@@ -54,9 +54,13 @@ class MailerLite_Gutenberg {
 	 */
 	public static function ajax_forms() {
 		global $wpdb;
-		$forms_data = $wpdb->get_results(
-			"SELECT * FROM " . $wpdb->base_prefix . "mailerlite_forms ORDER BY time DESC"
-		);
+
+		$query = "
+			SELECT * FROM
+			{$wpdb->base_prefix}mailerlite_forms
+			ORDER BY time DESC
+		";
+		$forms_data = $wpdb->get_results($query);
 
 		$forms_data = array_map( function ( $form ) {
 			return [
@@ -86,9 +90,14 @@ class MailerLite_Gutenberg {
 	public function form_preview_iframe() {
 		global $wpdb;
 
-		$form = $wpdb->get_results(
-			"SELECT * FROM `" . $wpdb->base_prefix . "mailerlite_forms` WHERE `id` = " . $_POST['form_id'] . " ORDER BY time DESC"
+		$query = $wpdb->prepare(
+			"SELECT * FROM
+			{$wpdb->base_prefix}mailerlite_forms
+			WHERE id = %d
+			ORDER BY time DESC",
+			$_POST['form_id']
 		);
+		$form = $wpdb->get_results($query);
 
 		if ( count( $form ) === 0 ) {
 			echo wp_send_json_success( [ 'html' => false, 'edit_link' => false ] );

--- a/trunk/include/mailerlite-shortcode.php
+++ b/trunk/include/mailerlite-shortcode.php
@@ -79,9 +79,11 @@ class MailerLite_Shortcode {
 			return;
 		}
 
-		$forms = $wpdb->get_results(
-			"SELECT * FROM " . $wpdb->base_prefix . "mailerlite_forms"
-		);
+		$query = "
+			SELECT *
+			FROM {$wpdb->base_prefix}mailerlite_forms
+		";
+		$forms = $wpdb->get_results($query);
 
 		include( MAILERLITE_PLUGIN_DIR . 'include/templates/common/tiny_mce.php' );
 
@@ -110,9 +112,14 @@ class MailerLite_Shortcode {
 	public function redirect_to_form_edit() {
 		global $wpdb;
 
-		$form = $wpdb->get_row(
-			"SELECT * FROM `" . $wpdb->base_prefix . "mailerlite_forms` WHERE `id` = " . $_GET['form_id'] . " ORDER BY time DESC"
+		$query = $wpdb->prepare(
+			"SELECT * FROM
+			{$wpdb->base_prefix}mailerlite_forms
+			WHERE id = %d
+			ORDER BY time DESC",
+			$_GET['form_id']
 		);
+		$form = $wpdb->get_row($query);
 
 		if ( $form != null ) {
 			if ( $form->type == MailerLite_Form::TYPE_CUSTOM ) {

--- a/trunk/include/mailerlite-widget.php
+++ b/trunk/include/mailerlite-widget.php
@@ -35,10 +35,13 @@ class MailerLite_Widget extends WP_Widget {
 		           && intval(
 			           $instance['mailerlite_form_id']
 		           ) ? $instance['mailerlite_form_id'] : 0;
-		$form    = $wpdb->get_row(
-			"SELECT * FROM " . $wpdb->base_prefix . "mailerlite_forms WHERE id = "
-			. $form_id
+		$query = $wpdb->prepare(
+			"SELECT * FROM
+			{$wpdb->base_prefix}mailerlite_forms
+			WHERE id = %d",
+			$form_id
 		);
+		$form = $wpdb->get_row($query);
 
 		if ( isset( $form->data ) ) {
 			$form_data = unserialize( $form->data );
@@ -66,10 +69,12 @@ class MailerLite_Widget extends WP_Widget {
 	public function form( $instance ) {
 		global $wpdb;
 
-		$forms_data = $wpdb->get_results(
-			"SELECT * FROM " . $wpdb->base_prefix
-			. "mailerlite_forms ORDER BY time DESC"
-		);
+		$query = "
+			SELECT * FROM
+			{$wpdb->base_prefix}mailerlite_forms
+			ORDER BY time DESC
+		";
+		$forms_data = $wpdb->get_results($query);
 
 		if ( isset( $instance['mailerlite_form_id'] ) ) {
 			$id = $instance['mailerlite_form_id'];

--- a/trunk/mailerlite.php
+++ b/trunk/mailerlite.php
@@ -29,7 +29,7 @@
 define( 'MAILERLITE_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'MAILERLITE_PLUGIN_URL', plugins_url( '', __FILE__ ) );
 
-define( 'MAILERLITE_VERSION', '1.4.2' );
+define( 'MAILERLITE_VERSION', '1.4.4' );
 
 define( 'MAILERLITE_PHP_VERSION', '5.6.0' );
 define( 'MAILERLITE_WP_VERSION', '3.0.1' );
@@ -83,13 +83,25 @@ function mailerlite_install() {
            ) DEFAULT " . $charset_collate . ";";
 	dbDelta( $sql );
 
-	$sql = "ALTER TABLE  " . $table_name . " " . $charset_collate . ";";
+	$sql = $wpdb->prepare(
+		"ALTER TABLE %s %s;",
+		$table_name,
+		$charset_collate
+	);
 	$wpdb->query( $sql );
 
-	$sql = "ALTER TABLE  " . $table_name . " CHANGE  `name`  `name` TINYTEXT " . $charset_collate . ";";
+	$sql = $wpdb->prepare(
+		"ALTER TABLE  %s CHANGE  `name` `name` TINYTEXT %s;",
+		$table_name,
+		$charset_collate
+	);
 	$wpdb->query( $sql );
 
-	$sql = "ALTER TABLE  " . $table_name . " CHANGE  `data`  `data` TEXT " . $charset_collate . ";";
+	$sql = $wpdb->prepare(
+		"ALTER TABLE %s CHANGE  `data` `data` TEXT %s;",
+		$table_name,
+		$charset_collate
+	);
 	$wpdb->query( $sql );
 }
 
@@ -142,8 +154,11 @@ function mailerlite_status_information() {
 
 	// Only if loading the plugin succeeded
 	if ( class_exists( 'MailerLite_Form' ) ) {
-		$forms                    = $wpdb->get_results( sprintf( "SELECT * FROM %smailerlite_forms",
-			$wpdb->base_prefix ) );
+		$query = "
+			SELECT *
+			FROM {$wpdb->base_prefix}mailerlite_forms
+		";
+		$forms = $wpdb->get_results($query);
 		$number_of_custom_forms   = 0;
 		$number_of_embedded_forms = 0;
 

--- a/trunk/readme.txt
+++ b/trunk/readme.txt
@@ -3,9 +3,9 @@ Contributors: mailerlite
 Donate link: https://www.mailerlite.com/
 Tags: mailerlite, newsletter, subscribe, form, webform
 Requires at least: 3.0.1
-Tested up to: 5.3.2
+Tested up to: 5.4.1
 Requires PHP: 5.6.0
-Stable tag: 1.4.3
+Stable tag: 1.4.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## Description

A reported SQL injection security issue on our wordpress admin pages. Also publicly available `ajax_` methods can be accessed even if not logged in as an anonymous user, although it only pulls groups, it is still a security hole.

## Changes

 - Prepare all SQL statements before executing them to avoid injections 
- Do not allow the AJAX method to pull more groups to be called unless current user is an administrator
 - Bump versions

## Notes

Ajax method to pull groups got a validation to check for `administrator` role so even if the user is logged in but is below that level it will return the error. Not sure if _regular_ users are allowed to change settings/forms on this plugin.